### PR TITLE
Simplify triplets

### DIFF
--- a/triplets/toolchains/x64-windows-clangcl.toolchain.cmake
+++ b/triplets/toolchains/x64-windows-clangcl.toolchain.cmake
@@ -1,0 +1,11 @@
+# Get Program Files root to lookup possible LLVM installation
+file(TO_CMAKE_PATH "$ENV{ProgramW6432}/LLVM/bin" LLVM_BIN_DIR)
+
+# Set NO_DEFAULT_PATH to prevent the toolchain from picking up the copy of LLVM which ships with
+# Visual Studio, which may be outdated
+find_program(CLANG_CL_EXECUTABLE NAMES "clang-cl.exe" PATHS ${LLVM_BIN_DIR} NO_DEFAULT_PATH REQUIRED)
+find_program(CLANG_RC_EXECUTABLE NAMES "llvm-rc.exe" PATHS ${LLVM_BIN_DIR} NO_DEFAULT_PATH REQUIRED)
+
+set(CMAKE_C_COMPILER ${CLANG_CL_EXECUTABLE} CACHE STRING "" FORCE)
+set(CMAKE_CXX_COMPILER ${CLANG_CL_EXECUTABLE} CACHE STRING "" FORCE)
+set(CMAKE_RC_COMPILER  ${CLANG_RC_EXECUTABLE} CACHE STRING "" FORCE)

--- a/triplets/x64-windows-llvm.cmake
+++ b/triplets/x64-windows-llvm.cmake
@@ -3,5 +3,12 @@ set(VCPKG_LIBRARY_LINKAGE dynamic)
 set(VCPKG_CRT_LINKAGE dynamic)
 
 # Configure toolchain
-set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/toolchains/x64-windows-llvm.toolchain.cmake")
+# Some ports need to be built with clang-cl instead of clang.  For example,
+# libffi uses libtool, which pass msvc-style arguments to the linker (-EXPORT:symbol)
+if(PORT MATCHES "libffi")
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/toolchains/x64-windows-clangcl.toolchain.cmake")
+else()
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/toolchains/x64-windows-llvm.toolchain.cmake")
+endif()
+
 set(VCPKG_LOAD_VCVARS_ENV ON)


### PR DESCRIPTION
- Enable the use of clang-cl instead of clang for specific ports