### PR TITLE
Use clang 19.x-objc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,6 @@ on:
 jobs:
   windows:
     runs-on: windows-2022
-    env:
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
     steps:
       - uses: actions/checkout@v4
       - name: Checkout vcpkg repo
@@ -20,12 +18,12 @@ jobs:
           ref: 2024.08.23
           fetch-depth: 1
           path: vcpkg
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');     
+      - name: Install clang 19.x-objc
+        run: |
+          Remove-Item -Recurse 'C:\Program Files\LLVM\'
+          Invoke-WebRequest -UseBasicParsing -Uri https://qmcdn.blob.core.windows.net/gnustep/clang-19.x-objc.zip -OutFile clang-19.x-objc.zip
+          Expand-Archive -Path clang-19.x-objc.zip -DestinationPath 'C:\Program Files\LLVM\' -Force
+          & 'C:\Program Files\LLVM\bin\clang.exe' --version
       - name: Check LLVM version
         # We need at least LLVM 18.0 for proper Objective C support.  Visual Studio 2022 ships with LLVM 17,
         # so we need to make sure we pick up clang from C:\Program Files\LLVM\bin\


### PR DESCRIPTION
This version of clang is built off the 19.x (pre-)release branch with https://github.com/llvm/llvm-project/commit/7c25ae87f7378f38aa49a92b9cf8092deb95a1f4 backported

Build: https://github.com/qmfrederik/llvm-project/actions/runs/10830887391
Source: https://github.com/qmfrederik/llvm-project/tree/builds/19.x-objc