### PR TITLE
Make sure release and debug files are installed correctly

### DIFF
--- a/ports/gnustep-base/portfile.cmake
+++ b/ports/gnustep-base/portfile.cmake
@@ -22,16 +22,10 @@ vcpkg_configure_gnustep(
     OPTIONS
         # GNUstep.conf contains absolute paths, and doesn't exist in vcpkg
         --disable-importing-config-file
-        # gnustep-config is not in PATH, so specify the path to the makefiles
-        GNUSTEP_MAKEFILES=${CURRENT_INSTALLED_DIR}/share/GNUstep/Makefiles/
         ${options}
 )
 
-vcpkg_install_gnustep(
-    OPTIONS
-        # gnustep-config is not in PATH, so specify the path to the makefiles
-        GNUSTEP_MAKEFILES=${CURRENT_INSTALLED_DIR}/share/GNUstep/Makefiles/
-)
+vcpkg_install_gnustep()
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/gnustep-gui/portfile.cmake
+++ b/ports/gnustep-gui/portfile.cmake
@@ -34,3 +34,6 @@ vcpkg_install_gnustep()
 vcpkg_fixup_pkgconfig()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.LIB")
+
+# GNUstep Makefiles go in share/ and are different for release and debug configurations
+set(VCPKG_POLICY_ALLOW_DEBUG_SHARE enabled)

--- a/ports/gnustep-headless/portfile.cmake
+++ b/ports/gnustep-headless/portfile.cmake
@@ -23,18 +23,10 @@ if (VCPKG_TARGET_IS_WINDOWS)
         string(REGEX REPLACE "^([a-zA-Z]):/" "/\\1/" current_installed_dir_msys "${current_installed_dir_msys}")
     endif()
 
-    # gnustep-config is not in PATH, so specify the path to the makefiles
-    vcpkg_list(APPEND options "GNUSTEP_MAKEFILES=${current_installed_dir_msys}/share/GNUstep/Makefiles/")
-
     # fixme: Utilities such as plutil are not installed in the debug/bin location, so always add ${CURRENT_INSTALLED_DIR}/bin
     # to path
     set(path_backup $ENV{PATH})
-    vcpkg_add_to_path("${current_installed_dir_msys}/bin/")
-    vcpkg_add_to_path("${current_installed_dir_msys}/tools/gnustep-base/")
-else()
-    # gnustep-config is not in PATH, so specify the path to the makefiles
-    vcpkg_list(APPEND options "GNUSTEP_MAKEFILES=${CURRENT_INSTALLED_DIR}/share/GNUstep/Makefiles/")
-    vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/gnustep-base/")
+    vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/bin/")
 endif ()
 
 vcpkg_configure_gnustep(

--- a/ports/gnustep-headless/portfile.cmake
+++ b/ports/gnustep-headless/portfile.cmake
@@ -12,7 +12,10 @@ vcpkg_from_github(
 
 vcpkg_list(SET options)
 
+# Utilities such as plutil and plmerge are installed to /tools, so always add ${CURRENT_INSTALLED_DIR}/tools
+# to path
 # TODO: We could/should move this logic into vcpkg_configure_gnustep, as that method also calculates current_installed_dir_msys
+set(path_backup $ENV{PATH})
 if (VCPKG_TARGET_IS_WINDOWS)
     # Some PATH handling for dealing with spaces....some tools will still fail with that!
     # In particular, the libtool install command is unable to install correctly to paths with spaces.
@@ -23,11 +26,10 @@ if (VCPKG_TARGET_IS_WINDOWS)
         string(REGEX REPLACE "^([a-zA-Z]):/" "/\\1/" current_installed_dir_msys "${current_installed_dir_msys}")
     endif()
 
-    # fixme: Utilities such as plutil are not installed in the debug/bin location, so always add ${CURRENT_INSTALLED_DIR}/bin
-    # to path
-    set(path_backup $ENV{PATH})
-    vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/bin/")
-endif ()
+    vcpkg_add_to_path("${current_installed_dir_msys}/tools/gnustep-base/")
+else()
+    vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/gnustep-base/")
+endif()
 
 vcpkg_configure_gnustep(
     SOURCE_PATH ${SOURCE_PATH}

--- a/ports/gnustep-make/FilesystemLayouts/vcpkg-debug
+++ b/ports/gnustep-make/FilesystemLayouts/vcpkg-debug
@@ -1,0 +1,62 @@
+GNUSTEP_DEFAULT_PREFIX=/usr/local
+
+# These are only used by gnustep-base to implement the NSUserDirectory
+# API.  We never install anything in them.  They will be used as they
+# are without $prefix.
+GNUSTEP_SYSTEM_USERS_DIR=/home
+GNUSTEP_NETWORK_USERS_DIR=/home
+GNUSTEP_LOCAL_USERS_DIR=/home
+
+# NB: $prefix will be added to all the MAKEFILES/SYSTEM/NETWORK/LOCAL
+# paths.
+GNUSTEP_MAKEFILES=/share/GNUstep/Makefiles
+
+GNUSTEP_SYSTEM_APPS=/@libdir@/GNUstep/Applications
+GNUSTEP_SYSTEM_ADMIN_APPS=/@libdir@/GNUstep/Applications
+GNUSTEP_SYSTEM_WEB_APPS=/@libdir@/GNUstep/WebApplications
+GNUSTEP_SYSTEM_TOOLS=/bin
+GNUSTEP_SYSTEM_ADMIN_TOOLS=/sbin
+GNUSTEP_SYSTEM_LIBRARY=/@libdir@/GNUstep
+GNUSTEP_SYSTEM_HEADERS=/../include
+GNUSTEP_SYSTEM_LIBRARIES=/@libdir@
+GNUSTEP_SYSTEM_DOC=/../share/GNUstep/Documentation
+GNUSTEP_SYSTEM_DOC_MAN=/../share/man
+GNUSTEP_SYSTEM_DOC_INFO=/../share/info
+
+GNUSTEP_NETWORK_APPS=/@libdir@/GNUstep/Applications
+GNUSTEP_NETWORK_ADMIN_APPS=/@libdir@/GNUstep/Applications
+GNUSTEP_NETWORK_WEB_APPS=/@libdir@/GNUstep/WebApplications
+GNUSTEP_NETWORK_TOOLS=/bin
+GNUSTEP_NETWORK_ADMIN_TOOLS=/sbin
+GNUSTEP_NETWORK_LIBRARY=/@libdir@/GNUstep
+GNUSTEP_NETWORK_HEADERS=/../include
+GNUSTEP_NETWORK_LIBRARIES=/@libdir@
+GNUSTEP_NETWORK_DOC=/../share/GNUstep/Documentation
+GNUSTEP_NETWORK_DOC_MAN=/../share/man
+GNUSTEP_NETWORK_DOC_INFO=/../share/info
+
+GNUSTEP_LOCAL_APPS=/@libdir@/GNUstep/Applications
+GNUSTEP_LOCAL_ADMIN_APPS=/@libdir@/GNUstep/Applications
+GNUSTEP_LOCAL_WEB_APPS=/@libdir@/GNUstep/WebApplications
+GNUSTEP_LOCAL_TOOLS=/bin
+GNUSTEP_LOCAL_ADMIN_TOOLS=/sbin
+GNUSTEP_LOCAL_LIBRARY=/@libdir@/GNUstep
+GNUSTEP_LOCAL_HEADERS=/../include
+GNUSTEP_LOCAL_LIBRARIES=/@libdir@
+GNUSTEP_LOCAL_DOC=/../share/GNUstep/Documentation
+GNUSTEP_LOCAL_DOC_MAN=/../share/man
+GNUSTEP_LOCAL_DOC_INFO=/../share/info
+
+GNUSTEP_USER_DIR_APPS=GNUstep/Applications
+GNUSTEP_USER_DIR_ADMIN_APPS=GNUstep/Applications/Admin
+GNUSTEP_USER_DIR_WEB_APPS=GNUstep/WebApplications
+GNUSTEP_USER_DIR_TOOLS=GNUstep/Tools
+GNUSTEP_USER_DIR_ADMIN_TOOLS=GNUstep/Tools/Admin
+GNUSTEP_USER_DIR_LIBRARY=GNUstep/Library
+GNUSTEP_USER_DIR_HEADERS=GNUstep/Library/Headers
+GNUSTEP_USER_DIR_LIBRARIES=GNUstep/Library/Libraries
+GNUSTEP_USER_DIR_DOC=GNUstep/Library/Documentation
+GNUSTEP_USER_DIR_DOC_MAN=GNUstep/Library/Documentation/man
+GNUSTEP_USER_DIR_DOC_INFO=GNUstep/Library/Documentation/info
+GNUSTEP_USER_CONFIG_FILE=.GNUstep.conf
+GNUSTEP_USER_DEFAULTS_DIR=GNUstep/Defaults

--- a/ports/gnustep-make/portfile.cmake
+++ b/ports/gnustep-make/portfile.cmake
@@ -19,11 +19,12 @@ vcpkg_configure_gnustep(
 vcpkg_install_gnustep()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
 # Empty directories
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/Additional")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share/GNUstep/Makefiles/Additional")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/Auxiliary")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share/GNUstep/Makefiles/Auxiliary")
 
 # Utilities which are not used in the build process and contain absolute path
 file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/debugapp")
@@ -43,7 +44,9 @@ file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/etc/GNUstep/GNUstep.conf")
 # We don't use .csh files in the build process. They contain absolute paths;
 # remove them.
 file(REMOVE "${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/GNUstep.csh")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/share/GNUstep/Makefiles/GNUstep.csh")
 file(REMOVE "${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/filesystem.csh")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/share/GNUstep/Makefiles/filesystem.csh")
 
 # Fix path in gnustep-config, GNUstep.sh, GNUstep.conf and filesystem.sh
 function(z_vcpkg_fixup_gnustep_path file find replace)
@@ -62,19 +65,21 @@ if (CMAKE_HOST_WIN32)
 endif()
 
 z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/bin/gnustep-config" "${vcpkg_package_prefix}" "$(realpath \"$(dirname $0)/../\")")
-
-if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-    # ./debug/share does not exist, so redirect to ./share; but fixup the other paths relative to ./debug
-    z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/debug/bin/gnustep-config" "${vcpkg_package_prefix}/debug/share" "$(realpath \"$(dirname $0)/../../share/\")")
-    z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/debug/bin/gnustep-config" "${vcpkg_package_prefix}" "$(realpath \"$(dirname $0)/../\")")
-endif()
+z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/debug/bin/gnustep-config" "${vcpkg_package_prefix}/debug" "$(realpath \"$(dirname $0)/../\")")
 
 # because GNUstep.sh is sourced, use ${BASH_SOURCE[0]}.  This is less portable but works.
 z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/GNUstep.sh" "${vcpkg_package_prefix}" "$(realpath \"$(dirname \${BASH_SOURCE[0]})/../../../\")")
+z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/debug/share/GNUstep/Makefiles/GNUstep.sh" "${vcpkg_package_prefix}/debug" "$(realpath \"$(dirname \${BASH_SOURCE[0]})/../../../\")")
+
 z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/GNUstep-reset.sh" "${vcpkg_package_prefix}" "$(realpath \"$(dirname \${BASH_SOURCE[0]})/../../../\")")
+z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/debug/share/GNUstep/Makefiles/GNUstep-reset.sh" "${vcpkg_package_prefix}/debug" "$(realpath \"$(dirname \${BASH_SOURCE[0]})/../../../\")")
+
 z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/filesystem.sh" "${vcpkg_package_prefix}" "$(realpath \"$(dirname \${BASH_SOURCE[0]})/../../../\")")
+z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/debug/share/GNUstep/Makefiles/filesystem.sh" "${vcpkg_package_prefix}/debug" "$(realpath \"$(dirname \${BASH_SOURCE[0]})/../../../\")")
 
 # gnustep-make has no headers
 set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
 
+# The makefiles used by GNUstep go in share, and are different for the release and debug configuration
+set(VCPKG_POLICY_ALLOW_DEBUG_SHARE enabled)
 set(VCPKG_POLICY_ALLOW_EMPTY_FOLDERS enabled)

--- a/ports/gnustep-make/portfile.cmake
+++ b/ports/gnustep-make/portfile.cmake
@@ -9,11 +9,15 @@ vcpkg_from_github(
     PATCHES
 )
 
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/FilesystemLayouts/vcpkg-debug DESTINATION ${SOURCE_PATH}/FilesystemLayouts/)
+
 vcpkg_configure_gnustep(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
         --with-library-combo=ng-gnu-gnu
         --with-runtime-abi=gnustep-2.2
+    OPTIONS_DEBUG
+        --with-layout=vcpkg-debug
 )
 
 vcpkg_install_gnustep()

--- a/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
+++ b/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
@@ -79,25 +79,28 @@ function(vcpkg_configure_gnustep)
             list(APPEND all_buildtypes RELEASE)
         endif()
 
-        # Allow ./configure to find gnustep-config, which is in bin/
-        set(path_backup $ENV{PATH})
-        vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}${path_suffix_${current_buildtype}}/bin")
-
         foreach(current_buildtype IN LISTS all_buildtypes)
-            vcpkg_list(APPEND CONFIGURE_OPTIONS
-                                # ${prefix} has an extra backslash to prevent early expansion when calling `bash -c configure "..."`.
-                                "--prefix=${current_installed_dir_msys}${path_suffix_${current_buildtype}}"
-                                # Important: These should all be relative to prefix!
-                                "--bindir=\\\${prefix}/../tools/${PORT}${path_suffix_${current_buildtype}}/bin"
-                                "--sbindir=\\\${prefix}/../tools/${PORT}${path_suffix_${current_buildtype}}/sbin"
-                                "--libdir=\\\${prefix}/lib" # On some Linux distributions lib64 is the default
-                                "--datarootdir=\\\${prefix}/share/${PORT}"
-                                "--host=x86_64-pc-windows"
-                                "--target=x86_64-pc-windows"
-                                "CC=${GNUSTEP_C_COMPILER_NAME}"
-                                "CXX=${GNUSTEP_CXX_COMPILER_NAME}"
-                                "LDFLAGS=-fuse-ld=${GNUSTEP_LINKER_NAME}"
-                                ${arg_OPTIONS})
+            # Allow ./configure to find gnustep-config, which is in bin/
+            set(path_backup $ENV{PATH})
+            vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}${path_suffix_${current_buildtype}}/bin")
+
+            # The same variable will be re-used in the foreach loop, so make sure to use set instead of
+            # append!
+            vcpkg_list(
+                SET CONFIGURE_OPTIONS
+                # ${prefix} has an extra backslash to prevent early expansion when calling `bash -c configure "..."`.
+                "--prefix=${current_installed_dir_msys}${path_suffix_${current_buildtype}}"
+                # Important: These should all be relative to prefix!
+                "--bindir=\\\${prefix}/../tools/${PORT}${path_suffix_${current_buildtype}}/bin"
+                "--sbindir=\\\${prefix}/../tools/${PORT}${path_suffix_${current_buildtype}}/sbin"
+                "--libdir=\\\${prefix}/lib" # On some Linux distributions lib64 is the default
+                "--datarootdir=\\\${prefix}/share/${PORT}"
+                "--host=x86_64-pc-windows"
+                "--target=x86_64-pc-windows"
+                "CC=${GNUSTEP_C_COMPILER_NAME}"
+                "CXX=${GNUSTEP_CXX_COMPILER_NAME}"
+                "LDFLAGS=-fuse-ld=${GNUSTEP_LINKER_NAME}"
+                ${arg_OPTIONS})
 
             list(JOIN CONFIGURE_OPTIONS " " CONFIGURE_OPTIONS)
 
@@ -111,9 +114,9 @@ function(vcpkg_configure_gnustep)
                 LOGNAME "config-${TARGET_TRIPLET}-${short_name_${current_buildtype}}"
                 SAVE_LOG_FILES config.log
             )
-        endforeach()
         
-        set(ENV{PATH} "${path_backup}")
+            set(ENV{PATH} "${path_backup}")
+        endforeach()
     else()
         message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} is not implemented for your platform")
     endif()

--- a/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
+++ b/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
@@ -21,8 +21,10 @@ function(vcpkg_configure_gnustep)
                 ${arg_OPTIONS}
             OPTIONS_DEBUG
                 ${arg_OPTIONS_DEBUG}
+                "GNUSTEP_MAKEFILES=${CURRENT_INSTALLED_DIR}/debug/share/GNUstep/Makefiles/"
             OPTIONS_RELEASE
                 ${arg_OPTIONS_RELEASE}
+                "GNUSTEP_MAKEFILES=${CURRENT_INSTALLED_DIR}/share/GNUstep/Makefiles/"
         )
     elseif(VCPKG_TARGET_IS_WINDOWS)
         # We don't use vcpkg_configure_make on Windows because it ends up breaking the linker in such a way that it cannot
@@ -104,6 +106,7 @@ function(vcpkg_configure_gnustep)
                 "CC=${GNUSTEP_C_COMPILER_NAME}"
                 "CXX=${GNUSTEP_CXX_COMPILER_NAME}"
                 "LDFLAGS=-fuse-ld=${GNUSTEP_LINKER_NAME}"
+                "GNUSTEP_MAKEFILES=${current_installed_dir_msys}${path_suffix_${current_buildtype}}/share/GNUstep/Makefiles/"
                 ${arg_OPTIONS}
                 ${arg_OPTIONS_${current_buildtype}})
 

--- a/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
+++ b/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
@@ -4,7 +4,7 @@ function(vcpkg_configure_gnustep)
     cmake_parse_arguments(PARSE_ARGV 0 "arg"
         ""
         "SOURCE_PATH"
-        "OPTIONS"
+        "OPTIONS;OPTIONS_DEBUG;OPTIONS_RELEASE"
     )
 
     if(VCPKG_TARGET_IS_LINUX)
@@ -19,6 +19,10 @@ function(vcpkg_configure_gnustep)
             OPTIONS
                 "LDFLAGS=-fuse-ld=lld"
                 ${arg_OPTIONS}
+            OPTIONS_DEBUG
+                ${arg_OPTIONS_DEBUG}
+            OPTIONS_RELEASE
+                ${arg_OPTIONS_RELEASE}
         )
     elseif(VCPKG_TARGET_IS_WINDOWS)
         # We don't use vcpkg_configure_make on Windows because it ends up breaking the linker in such a way that it cannot
@@ -100,7 +104,8 @@ function(vcpkg_configure_gnustep)
                 "CC=${GNUSTEP_C_COMPILER_NAME}"
                 "CXX=${GNUSTEP_CXX_COMPILER_NAME}"
                 "LDFLAGS=-fuse-ld=${GNUSTEP_LINKER_NAME}"
-                ${arg_OPTIONS})
+                ${arg_OPTIONS}
+                ${arg_OPTIONS_${current_buildtype}})
 
             list(JOIN CONFIGURE_OPTIONS " " CONFIGURE_OPTIONS)
 


### PR DESCRIPTION
We were appending to `CONFIGURE_OPTIONS` inside the loop instead of resetting it at every iteration. This caused the release configuration variables to leak into the debug build.