### PR TITLE
Install GNUstep tools in the /tools directory

### DIFF
--- a/ports/gnustep-base/portfile.cmake
+++ b/ports/gnustep-base/portfile.cmake
@@ -36,3 +36,36 @@ vcpkg_install_gnustep(
 vcpkg_fixup_pkgconfig()
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.LIB")
+
+# Copy tools to the tools directory, remove duplicate instances in debug/
+vcpkg_copy_tools(
+    TOOL_NAMES
+        autogsdoc
+        cvtenc
+        defaults
+        gdnc
+        gspath
+        HTMLLinker
+        make_strings
+        pl
+        pl2link
+        pldes
+        plget
+        plmerge
+        plparse
+        plser
+        plutil
+        sfparse
+        xmlparse
+    AUTO_CLEAN
+)
+
+if (NOT VCPKG_TARGET_IS_WINDOWS)
+    vcpkg_copy_tools(
+        TOOL_NAMES
+            gdomap
+        AUTO_CLEAN)
+endif ()
+
+# The makefiles used by GNUstep go in share, and are different for the release and debug configuration
+set(VCPKG_POLICY_ALLOW_DEBUG_SHARE enabled)

--- a/ports/gnustep-base/portfile.cmake
+++ b/ports/gnustep-base/portfile.cmake
@@ -38,33 +38,109 @@ vcpkg_fixup_pkgconfig()
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING.LIB")
 
 # Copy tools to the tools directory, remove duplicate instances in debug/
-vcpkg_copy_tools(
-    TOOL_NAMES
-        autogsdoc
-        cvtenc
-        defaults
-        gdnc
-        gspath
-        HTMLLinker
-        make_strings
-        pl
-        pl2link
-        pldes
-        plget
-        plmerge
-        plparse
-        plser
-        plutil
-        sfparse
-        xmlparse
-    AUTO_CLEAN
-)
+if (VCPKG_TARGET_IS_WINDOWS)
+    # vcpkg_copy_tools fails with the following error:
+    #  CMake Error at scripts/cmake/vcpkg_copy_tool_dependencies.cmake:31 (message):
+    #  Could not find PowerShell Core; please open an issue to report this.
+    # so do a manual copy instead
+    file(
+        COPY
+            ${CURRENT_PACKAGES_DIR}/bin/autogsdoc.exe
+            ${CURRENT_PACKAGES_DIR}/bin/cvtenc.exe
+            ${CURRENT_PACKAGES_DIR}/bin/defaults.exe
+            ${CURRENT_PACKAGES_DIR}/bin/gdnc.exe
+            ${CURRENT_PACKAGES_DIR}/bin/gspath.exe
+            ${CURRENT_PACKAGES_DIR}/bin/HTMLLinker.exe
+            ${CURRENT_PACKAGES_DIR}/bin/make_strings.exe
+            ${CURRENT_PACKAGES_DIR}/bin/pl.exe
+            ${CURRENT_PACKAGES_DIR}/bin/pl2link.exe
+            ${CURRENT_PACKAGES_DIR}/bin/pldes.exe
+            ${CURRENT_PACKAGES_DIR}/bin/plget.exe
+            ${CURRENT_PACKAGES_DIR}/bin/plmerge.exe
+            ${CURRENT_PACKAGES_DIR}/bin/plparse.exe
+            ${CURRENT_PACKAGES_DIR}/bin/plser.exe
+            ${CURRENT_PACKAGES_DIR}/bin/plutil.exe
+            ${CURRENT_PACKAGES_DIR}/bin/sfparse.exe
+            ${CURRENT_PACKAGES_DIR}/bin/xmlparse.exe
 
-if (NOT VCPKG_TARGET_IS_WINDOWS)
+            # Shared libraries required by these tools
+            ${CURRENT_PACKAGES_DIR}/bin/gnustep-base-1_30.dll
+            ${CURRENT_INSTALLED_DIR}/bin/objc.dll
+            ${CURRENT_INSTALLED_DIR}/bin/iconv-2.dll
+            ${CURRENT_INSTALLED_DIR}/bin/libxml2.dll
+            ${CURRENT_INSTALLED_DIR}/bin/libxslt.dll
+            ${CURRENT_INSTALLED_DIR}/bin/libcurl.dll
+            ${CURRENT_INSTALLED_DIR}/bin/dispatch.dll
+            ${CURRENT_INSTALLED_DIR}/bin/ffi-8.dll
+            ${CURRENT_INSTALLED_DIR}/bin/liblzma.dll
+            ${CURRENT_INSTALLED_DIR}/bin/zlib1.dll
+
+        DESTINATION
+            ${CURRENT_PACKAGES_DIR}/tools/gnustep-base/
+    )
+
+    # Clean up after copying
+    file(
+        REMOVE
+            ${CURRENT_PACKAGES_DIR}/bin/autogsdoc.exe
+            ${CURRENT_PACKAGES_DIR}/bin/cvtenc.exe
+            ${CURRENT_PACKAGES_DIR}/bin/defaults.exe
+            ${CURRENT_PACKAGES_DIR}/bin/gdnc.exe
+            ${CURRENT_PACKAGES_DIR}/bin/gspath.exe
+            ${CURRENT_PACKAGES_DIR}/bin/HTMLLinker.exe
+            ${CURRENT_PACKAGES_DIR}/bin/make_strings.exe
+            ${CURRENT_PACKAGES_DIR}/bin/pl.exe
+            ${CURRENT_PACKAGES_DIR}/bin/pl2link.exe
+            ${CURRENT_PACKAGES_DIR}/bin/pldes.exe
+            ${CURRENT_PACKAGES_DIR}/bin/plget.exe
+            ${CURRENT_PACKAGES_DIR}/bin/plmerge.exe
+            ${CURRENT_PACKAGES_DIR}/bin/plparse.exe
+            ${CURRENT_PACKAGES_DIR}/bin/plser.exe
+            ${CURRENT_PACKAGES_DIR}/bin/plutil.exe
+            ${CURRENT_PACKAGES_DIR}/bin/sfparse.exe
+            ${CURRENT_PACKAGES_DIR}/bin/xmlparse.exe
+
+            ${CURRENT_PACKAGES_DIR}/debug/bin/autogsdoc.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/cvtenc.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/defaults.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/gdnc.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/gspath.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/HTMLLinker.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/make_strings.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/pl.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/pl2link.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/pldes.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/plget.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/plmerge.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/plparse.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/plser.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/plutil.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/sfparse.exe
+            ${CURRENT_PACKAGES_DIR}/debug/bin/xmlparse.exe
+    )
+else()
     vcpkg_copy_tools(
         TOOL_NAMES
+            autogsdoc
+            cvtenc
+            defaults
+            gdnc
+            gspath
             gdomap
-        AUTO_CLEAN)
+            HTMLLinker
+            make_strings
+            pl
+            pl2link
+            pldes
+            plget
+            plmerge
+            plparse
+            plser
+            plutil
+            sfparse
+            xmlparse
+        AUTO_CLEAN
+    )
 endif ()
 
 # The makefiles used by GNUstep go in share, and are different for the release and debug configuration

--- a/ports/gnustep-headless/portfile.cmake
+++ b/ports/gnustep-headless/portfile.cmake
@@ -29,10 +29,12 @@ if (VCPKG_TARGET_IS_WINDOWS)
     # fixme: Utilities such as plutil are not installed in the debug/bin location, so always add ${CURRENT_INSTALLED_DIR}/bin
     # to path
     set(path_backup $ENV{PATH})
-    vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/bin/")
+    vcpkg_add_to_path("${current_installed_dir_msys}/bin/")
+    vcpkg_add_to_path("${current_installed_dir_msys}/tools/gnustep-base/")
 else()
     # gnustep-config is not in PATH, so specify the path to the makefiles
     vcpkg_list(APPEND options "GNUSTEP_MAKEFILES=${CURRENT_INSTALLED_DIR}/share/GNUstep/Makefiles/")
+    vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/gnustep-base/")
 endif ()
 
 vcpkg_configure_gnustep(

--- a/ports/gnustep-headless/portfile.cmake
+++ b/ports/gnustep-headless/portfile.cmake
@@ -47,7 +47,9 @@ vcpkg_configure_gnustep(
         ${options}
 )
 
+vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/tools/gnustep-base/")
 vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}/bin/")
+
 vcpkg_install_gnustep()
 
 vcpkg_fixup_pkgconfig()


### PR DESCRIPTION
- Makes sure we always use the release builds of the tools
- Avoids mixing debug and release configurations