### PR TITLE
Use LLVM 20.0 on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,12 +22,6 @@ jobs:
           ref: 2024.08.23
           fetch-depth: 1
           path: vcpkg
-      - name: Install clang 19.x-objc
-        run: |
-          Remove-Item -Recurse 'C:\Program Files\LLVM\'
-          Invoke-WebRequest -UseBasicParsing -Uri https://qmcdn.blob.core.windows.net/gnustep/clang-19.x-objc.zip -OutFile clang-19.x-objc.zip
-          Expand-Archive -Path clang-19.x-objc.zip -DestinationPath 'C:\Program Files\LLVM\' -Force
-          & 'C:\Program Files\LLVM\bin\clang.exe' --version
       - name: Check LLVM version
         # We need at least LLVM 18.0 for proper Objective C support.  Visual Studio 2022 ships with LLVM 17,
         # so we need to make sure we pick up clang from C:\Program Files\LLVM\bin\

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ as an editor and Git for source code interations.
 - [LLVM](https://releases.llvm.org/download.html)
 - [Git for Windows](https://git-scm.com/download/win)
 
-You'll need a version of LLVM which includes [support for referencing instance variables which are in an external module](https://github.com/llvm/llvm-project/commit/7c25ae87f7378f38aa49a92b9cf8092deb95a1f4).  In practice, that means LLVM 20.0, which should be available
-near the end of 2024.  Meanwhile,  you can [download a prebuilt copy of LLVM](https://qmcdn.blob.core.windows.net/gnustep/clang-19.x-objc.zip)
-with this fix backported.
+You'll need a version of LLVM which includes [support for referencing instance variables which are in an external module](https://github.com/llvm/llvm-project/commit/7c25ae87f7378f38aa49a92b9cf8092deb95a1f4).  In practice, that means LLVM 20.0 or later, which you can download at https://releases.llvm.org/.
 
 To get started, run the following commands:
 


### PR DESCRIPTION
Upgrade to the windows-2025 image, which includes LLVM 20.0

Removes the need to use a custom build of LLVM.