### PR TITLE
Add LLVM bin directory to path for Meson build

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,40 @@ set RENOVATE_TOKEN=ghp_{your_token}
 set GITHUB_COM_TOKEN=ghp_{your_token}
 npx renovate {owner}/{repo}
 ```
+
+### Fixes for specific ports
+
+#### Using clang-cl
+Some ports should be compiled with [clang-cl](https://clang.llvm.org/docs/UsersManual.html#clang-cl), which uses a msvc-compatible command line syntax.
+
+Often, these ports fail to compile with a command-line invocation which appears to be a mix of clang and Visual C++ arguments, such as:
+
+```
+libtool: compile:  llvm-rc.exe -DPACKAGE_VERSION_STRING=\\\"0.22.5\\\" -DPACKAGE_VERSION_MAJOR=0 -DPACKAGE_VERSION_MINOR=22 -DPACKAGE_VERSION_SUBMINOR=5 -i ./../src/gettext-0-5775b97cd5.clean/gettext-runtime/intl/libintl.rc --output-format=coff  -o .libs/libintl.res.o
+```
+
+or
+
+```
+Detecting linker via: `"C:/Program Files/LLVM/bin/clang.exe" -O0 -g -Xclang -gcodeview -Wl,--version /LIBPATH:C:/Users/vagrant/Source/Repos/vcpkg-gnustep/vcpkg/installed/x64-windows-llvm/debug/lib "-fuse-ld=C:/Program Files/LLVM/bin/lld-link.exe"` -> 1
+stderr:
+clang: error: no such file or directory: '/LIBPATH:C:/Users/vagrant/Source/Repos/vcpkg-gnustep/vcpkg/installed/x64-windows-llvm/debug/lib'
+```
+
+To account for this, add the name of the port to the exception list in `triplets/x64-windows-llvm.cmake`.
+
+#### Compiling gettext-libintl
+
+This is a dependency of `cairo` but not `cairo[core]`.  Skip this dependency by building `cairo[core]`.
+
+#### Meson build errors
+
+If a Meson build fails with the the following error:
+
+```
+FileNotFoundError: [WinError 2] The system cannot find the file specified
+```
+
+Then this is most likely because Meson is looking for `lld-link` without specifying an explicit path (https://github.com/mesonbuild/meson/issues/9727).
+
+To account for this, add the name of the port to the exception list in `triplets/x64-windows-llvm.cmake`.

--- a/triplets/x64-windows-llvm.cmake
+++ b/triplets/x64-windows-llvm.cmake
@@ -15,6 +15,12 @@ else()
     set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/toolchains/x64-windows-llvm.toolchain.cmake")
 endif()
 
+# Workaround for meson-style projects, such as pixman, which try to look for lld-link in the current path
+# See https://github.com/mesonbuild/meson/issues/9727
+if(PORT MATCHES "^(pixman|cairo)$")
+    set(ENV{PATH} "$ENV{ProgramW6432}/LLVM/bin;$ENV{PATH}")
+endif()
+
 # Port-specific fixes which we should remove over time
 if(PORT MATCHES "liblzma")
     # Pretend to be msvc, as otherwise the build system will default to GCC-style semantics (and we're using clang)


### PR DESCRIPTION
Workaround for https://github.com/mesonbuild/meson/issues/9727

This isn't being detected in CI because the GitHub action runners have the LLVM/bin directory in PATH