### PR TITLE
Fix building Cairo with LLVM 20

### DIFF
--- a/ports/cairo/0001-Add-check-for-clang-to-cairo-attribute-handling-code.patch
+++ b/ports/cairo/0001-Add-check-for-clang-to-cairo-attribute-handling-code.patch
@@ -1,0 +1,25 @@
+From 6adc3f9103a6e75d3783eb6fe641fbcb95c8cc16 Mon Sep 17 00:00:00 2001
+From: Ryan VanderMeulen <rvandermeulen@mozilla.com>
+Date: Tue, 25 Feb 2025 11:13:44 -0500
+Subject: [PATCH] Add check for clang to cairo attribute handling code
+
+---
+ src/cairo-compiler-private.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/cairo-compiler-private.h b/src/cairo-compiler-private.h
+index 28455f99d..ab2d216e1 100644
+--- a/src/cairo-compiler-private.h
++++ b/src/cairo-compiler-private.h
+@@ -144,7 +144,7 @@
+ #define unlikely(expr) (expr)
+ #endif
+ 
+-#ifndef __GNUC__
++#if !defined(__GNUC__) && !defined (__clang__)
+ #undef __attribute__
+ #define __attribute__(x)
+ #endif
+-- 
+2.50.0.windows.1
+

--- a/ports/cairo/fix_clang-cl_build.patch
+++ b/ports/cairo/fix_clang-cl_build.patch
@@ -1,0 +1,37 @@
+diff --git a/util/cairo-script/cairo-script-objects.c b/util/cairo-script/cairo-script-objects.c
+index 2d7937be3..4d55ca848 100644
+--- a/util/cairo-script/cairo-script-objects.c	
++++ b/util/cairo-script/cairo-script-objects.c
+@@ -127,7 +127,7 @@ csi_array_append (csi_t *ctx,
+     return _csi_stack_push (ctx, &array->stack, csi_object_reference (obj));
+ }
+ 
+-inline csi_status_t
++csi_status_t
+ _csi_array_execute (csi_t *ctx, csi_array_t *array)
+ {
+     csi_integer_t i;
+diff --git a/meson.build b/meson.build
+index 7b20c0c48..9cb4a82ba 100644
+--- a/meson.build	
++++ b/meson.build
+@@ -38,7 +38,7 @@ cc = meson.get_compiler('c')
+ 
+ # Compiler flags
+ cflags = []
+-if cc.get_id() != 'msvc'
++if cc.get_argument_syntax() != 'msvc'
+   cflags += [
+     '-Wmissing-declarations',
+     '-Werror-implicit-function-declaration',
+@@ -159,8 +159,7 @@ check_headers = [
+ 
+ check_types = [
+   ['uint64_t', {'headers': ['stdint.h']}],
+-  ['uint128_t', {'headers': ['stdint.h']}],
+-  ['__uint128_t']
++  ['uint128_t', {'headers': ['stdint.h']}]
+ ]
+ 
+ check_funcs = [
+ 

--- a/ports/cairo/msvc-convenience.diff
+++ b/ports/cairo/msvc-convenience.diff
@@ -1,0 +1,15 @@
+diff --git a/src/win32/cairo-win32-private.h b/src/win32/cairo-win32-private.h
+index d457b78..0b1b4ed 100644
+--- a/src/win32/cairo-win32-private.h
++++ b/src/win32/cairo-win32-private.h
+@@ -53,6 +53,10 @@
+ 
+ #define WIN32_FONT_LOGICAL_SCALE 32
+ 
++#ifdef _MSC_VER 
++#pragma comment(lib, "MSImg32.Lib")
++#endif
++
+ CAIRO_BEGIN_DECLS
+ 
+ /* Surface DC flag values */

--- a/ports/cairo/portfile.cmake
+++ b/ports/cairo/portfile.cmake
@@ -1,0 +1,78 @@
+set(EXTRA_PATCHES "")
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    list(APPEND EXTRA_PATCHES fix_clang-cl_build.patch)
+endif()
+
+vcpkg_from_gitlab(
+    OUT_SOURCE_PATH SOURCE_PATH
+    GITLAB_URL https://gitlab.freedesktop.org
+    REPO cairo/cairo
+    REF "${VERSION}"
+    SHA512 663e6edf2718e8205e30ba309ac609ced9e88e6e1ec857fc48b345dfce82b044d58ec6b4a2d2b281fba30a659a368625ea7501f8b43fe26c137a7ebffdbaac91
+    PATCHES
+        msvc-convenience.diff
+        # https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/612
+        0001-Add-check-for-clang-to-cairo-attribute-handling-code.patch
+        ${EXTRA_PATCHES}
+)
+
+if("fontconfig" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dfontconfig=enabled)
+else()
+    list(APPEND OPTIONS -Dfontconfig=disabled)
+endif()
+
+if("freetype" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dfreetype=enabled)
+else()
+    list(APPEND OPTIONS -Dfreetype=disabled)
+endif()
+
+if ("x11" IN_LIST FEATURES)
+    message(WARNING "You will need to install Xorg dependencies to use feature x11:\nsudo apt install libx11-dev libxft-dev libxext-dev\n")
+    list(APPEND OPTIONS -Dxlib=enabled)
+else()
+    list(APPEND OPTIONS -Dxlib=disabled)
+endif()
+list(APPEND OPTIONS -Dxcb=disabled)
+list(APPEND OPTIONS -Dxlib-xcb=disabled)
+
+if("gobject" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dglib=enabled)
+else()
+    list(APPEND OPTIONS -Dglib=disabled)
+endif()
+
+if("lzo" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dlzo=enabled)
+else()
+    list(APPEND OPTIONS -Dlzo=disabled)
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${OPTIONS}
+        -Dtests=disabled
+        -Dzlib=enabled
+        -Dpng=enabled
+        -Dspectre=auto
+        -Dgtk2-utils=disabled
+        -Dsymbol-lookup=disabled
+)
+vcpkg_install_meson()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/cairo/cairo.h" "defined(CAIRO_WIN32_STATIC_BUILD)" "1")
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static" OR NOT VCPKG_TARGET_IS_WINDOWS)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING" "${SOURCE_PATH}/COPYING-LGPL-2.1" "${SOURCE_PATH}/COPYING-MPL-1.1")

--- a/ports/cairo/vcpkg.json
+++ b/ports/cairo/vcpkg.json
@@ -1,0 +1,66 @@
+{
+  "name": "cairo",
+  "version": "1.18.4",
+  "description": "Cairo is a 2D graphics library with support for multiple output devices. Currently supported output targets include the X Window System (via both Xlib and XCB), Quartz, Win32, image buffers, PostScript, PDF, and SVG file output. Experimental backends include OpenGL, BeOS, OS/2, and DirectFB.",
+  "homepage": "https://cairographics.org",
+  "license": "LGPL-2.1-only OR MPL-1.1",
+  "supports": "!xbox & !uwp",
+  "dependencies": [
+    "dirent",
+    "expat",
+    "libpng",
+    "pixman",
+    "pthread",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    },
+    "zlib"
+  ],
+  "default-features": [
+    "fontconfig",
+    "freetype"
+  ],
+  "features": {
+    "fontconfig": {
+      "description": "Build with fontconfig",
+      "dependencies": [
+        "fontconfig"
+      ]
+    },
+    "freetype": {
+      "description": "Use the freetype font backend",
+      "dependencies": [
+        {
+          "name": "freetype",
+          "default-features": false
+        }
+      ]
+    },
+    "gobject": {
+      "description": "Build the gobject module",
+      "dependencies": [
+        "glib"
+      ]
+    },
+    "lzo": {
+      "description": "Build with lzo support",
+      "dependencies": [
+        "lzo"
+      ]
+    },
+    "x11": {
+      "description": "Build with X11 support",
+      "supports": "!windows",
+      "dependencies": [
+        {
+          "name": "cairo",
+          "default-features": false,
+          "features": [
+            "fontconfig"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Cairo builds are failing on Windows (when using LLVM 20) because of this issue:

- https://github.com/llvm/llvm-project/issues/127792
- https://developercommunity.visualstudio.com/t/Build-failures-with-Windows-SDK-26100-Fe/10854761?
- https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/612

This commit backports https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/612 as a patch