### PR TITLE
Update libffi port

### DIFF
--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
     URLS "https://github.com/libffi/libffi/releases/download/v${VERSION}/libffi-${VERSION}.tar.gz"
     FILENAME "libffi-${VERSION}.tar.gz"
-    SHA512 d19f59a5b5d61bd7d9e8a7a74b8bf2e697201a19c247c410c789e93ca8678a4eb9f13c9bee19f129be80ade8514f6b1acb38d66f44d86edd32644ed7bbe31dd6
+    SHA512 3da9e21fdb920e7962ceb01ee671ef36196df4d5dad62e0cdd8e87cc60e350f241c204350560ae26ea04cc898161b5585c8a5a5125bdbcc84508efbb7ea61eb8
 )
 vcpkg_extract_source_archive(
     SOURCE_PATH
@@ -19,13 +19,12 @@ if(VCPKG_TARGET_IS_WINDOWS)
     vcpkg_list(APPEND options "CFLAGS=\${CFLAGS} ${linkage_flag}")
 endif()
 
-set(ccas_options "")
-vcpkg_cmake_get_vars(cmake_vars_file)
+vcpkg_cmake_get_vars(cmake_vars_file ADDITIONAL_LANGUAGES ASM)
 include("${cmake_vars_file}")
-set(ccas "${VCPKG_DETECTED_CMAKE_C_COMPILER}")
 if(VCPKG_DETECTED_CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     vcpkg_add_to_path("${SOURCE_PATH}")
-    set(ccas "msvcc.sh")
+    vcpkg_list(APPEND options "CCAS=msvcc.sh")
+    set(ccas_options "")
     if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
         string(APPEND ccas_options " -m32")
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
@@ -35,21 +34,14 @@ if(VCPKG_DETECTED_CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
         string(APPEND ccas_options " -marm64")
     endif()
-endif()
-vcpkg_list(APPEND options "CCAS='${ccas}'")
-if(ccas_options)
-    vcpkg_list(APPEND options "CCASFLAGS=\${CCASFLAGS}${ccas_options}")
-endif()
-
-set(configure_triplets DETERMINE_BUILD_TRIPLET)
-if(VCPKG_TARGET_IS_EMSCRIPTEN)
-    set(configure_triplets BUILD_TRIPLET "--host=wasm32-unknown-emscripten --build=\$(\$SHELL \"${SOURCE_PATH}/config.guess\")")
+    if(ccas_options)
+        vcpkg_list(APPEND options "CCASFLAGS=\${CCASFLAGS}${ccas_options}")
+    endif()
 endif()
 
-vcpkg_configure_make(
+vcpkg_make_configure(
     SOURCE_PATH "${SOURCE_PATH}"
-    ${configure_triplets}
-    USE_WRAPPERS
+    LANGUAGES C CXX ASM
     OPTIONS
         --enable-portable-binary
         --disable-docs
@@ -57,7 +49,7 @@ vcpkg_configure_make(
         ${options}
 )
 
-vcpkg_install_make()
+vcpkg_make_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -37,6 +37,8 @@ if(VCPKG_DETECTED_CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     if(ccas_options)
         vcpkg_list(APPEND options "CCASFLAGS=\${CCASFLAGS}${ccas_options}")
     endif()
+else()
+    vcpkg_list(APPEND options "CCAS='${VCPKG_DETECTED_CMAKE_C_COMPILER}'")
 endif()
 
 vcpkg_make_configure(

--- a/ports/libffi/usage
+++ b/ports/libffi/usage
@@ -1,10 +1,9 @@
-libffi can be imported via CMake FindPkgConfig module:
-
-    find_package(PkgConfig)
-    pkg_check_modules(LIBFFI REQUIRED IMPORTED_TARGET libffi)
-    target_link_libraries(main PRIVATE PkgConfig::LIBFFI)
-
 vcpkg provides proprietary CMake targets:
 
-    find_package(unofficial-libffi CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE unofficial::libffi::libffi)
+  find_package(unofficial-libffi CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE unofficial::libffi::libffi)
+
+libffi provides pkg-config modules:
+
+  # Library supporting Foreign Function Interfaces
+  libffi

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,13 +1,16 @@
 {
   "name": "libffi",
-  "version": "3.4.7",
-  "port-version": 1,
+  "version": "3.5.1",
   "description": "Portable, high level programming interface to various calling conventions",
   "homepage": "https://github.com/libffi/libffi",
   "license": "MIT",
   "dependencies": [
     {
       "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
+    {
+      "name": "vcpkg-make",
       "host": true
     }
   ]


### PR DESCRIPTION
Update to the latest version of the libffi port file and re-apply [5b92867](https://github.com/qmfrederik/vcpkg-gnustep/pull/46/commits/5b9286780cbce0fbd257fc1be03dbc4b193c1954).